### PR TITLE
Using double buffered ListView and TreeViews

### DIFF
--- a/Mafia2Libs/Controls/MListView.cs
+++ b/Mafia2Libs/Controls/MListView.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Mafia2Tool.Controls
+{
+    class MListView : ListView
+    {
+        public MListView()
+        {
+            this.DoubleBuffered = true;
+        }
+    }
+}

--- a/Mafia2Libs/Controls/MTreeView.cs
+++ b/Mafia2Libs/Controls/MTreeView.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Mafia2Tool.Controls
+{
+    public sealed class MTreeView : TreeView
+    {
+        private const int TVM_SETEXTENDEDSTYLE = 0x1100 + 44;
+        private const int TVS_EX_DOUBLEBUFFER = 0x0004;
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wp, IntPtr lp);
+
+        //fix from: (gotta love stack overflow!)
+        //https://stackoverflow.com/questions/14647216/c-sharp-treeview-ignore-double-click-only-at-checkbox
+        protected override void WndProc(ref Message m)
+        {
+            if (m.Msg == 0x0203 && CheckBoxes)
+            {
+                var localPos = this.PointToClient(Cursor.Position);
+                var hitTestInfo = this.HitTest(localPos);
+                if (hitTestInfo.Location == TreeViewHitTestLocations.StateImage)
+                {
+                    m.Msg = 0x0201;
+                }
+            }
+            base.WndProc(ref m);
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            SendMessage(this.Handle, TVM_SETEXTENDEDSTYLE, (IntPtr)TVS_EX_DOUBLEBUFFER, (IntPtr)TVS_EX_DOUBLEBUFFER);
+            base.OnHandleCreated(e);
+        }
+    }
+}

--- a/Mafia2Libs/Forms/ActorEditor.Designer.cs
+++ b/Mafia2Libs/Forms/ActorEditor.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ActorEditor));
             this.ActorGrid = new System.Windows.Forms.PropertyGrid();
-            this.ActorTreeView = new System.Windows.Forms.TreeView();
+            this.ActorTreeView = new Controls.MTreeView();
             this.ActorContext = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.ContextDelete = new System.Windows.Forms.ToolStripMenuItem();
             this.openM2T = new System.Windows.Forms.OpenFileDialog();

--- a/Mafia2Libs/Forms/ActorEditor.cs
+++ b/Mafia2Libs/Forms/ActorEditor.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Windows.Forms;
 using ResourceTypes.Actors;
+using Utils.Helpers;
 using Utils.Language;
 using Utils.Settings;
 using Forms.EditorControls;

--- a/Mafia2Libs/Forms/CityShopEditor.Designer.cs
+++ b/Mafia2Libs/Forms/CityShopEditor.Designer.cs
@@ -37,6 +37,7 @@
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.fileToolButton = new System.Windows.Forms.ToolStripDropDownButton();
             this.Button_SaveNonDLC = new System.Windows.Forms.ToolStripMenuItem();
+            this.Button_SaveDLC = new System.Windows.Forms.ToolStripMenuItem();
             this.ReloadButton = new System.Windows.Forms.ToolStripMenuItem();
             this.ExitButton = new System.Windows.Forms.ToolStripMenuItem();
             this.toolButton = new System.Windows.Forms.ToolStripDropDownButton();
@@ -46,13 +47,12 @@
             this.PopulateTranslokatorButton = new System.Windows.Forms.ToolStripMenuItem();
             this.DeleteAreaButton = new System.Windows.Forms.ToolStripMenuItem();
             this.DeleteDataButton = new System.Windows.Forms.ToolStripMenuItem();
-            this.treeView1 = new System.Windows.Forms.TreeView();
+            this.TreeView_CityShop = new Controls.MTreeView();
             this.propertyGrid1 = new System.Windows.Forms.PropertyGrid();
             this.TabControl = new System.Windows.Forms.TabControl();
             this.PropertyGridTab = new System.Windows.Forms.TabPage();
             this.DataGridTab = new System.Windows.Forms.TabPage();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
-            this.Button_SaveDLC = new System.Windows.Forms.ToolStripMenuItem();
             this.CollisionContext.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.TabControl.SuspendLayout();
@@ -115,21 +115,28 @@
             // Button_SaveNonDLC
             // 
             this.Button_SaveNonDLC.Name = "Button_SaveNonDLC";
-            this.Button_SaveNonDLC.Size = new System.Drawing.Size(180, 22);
+            this.Button_SaveNonDLC.Size = new System.Drawing.Size(134, 22);
             this.Button_SaveNonDLC.Text = "$SAVE";
             this.Button_SaveNonDLC.Click += new System.EventHandler(this.SaveButton_Click);
+            // 
+            // Button_SaveDLC
+            // 
+            this.Button_SaveDLC.Name = "Button_SaveDLC";
+            this.Button_SaveDLC.Size = new System.Drawing.Size(134, 22);
+            this.Button_SaveDLC.Text = "$SAVE_DLC";
+            this.Button_SaveDLC.Click += new System.EventHandler(this.SaveButtonDLC_Click);
             // 
             // ReloadButton
             // 
             this.ReloadButton.Name = "ReloadButton";
-            this.ReloadButton.Size = new System.Drawing.Size(180, 22);
+            this.ReloadButton.Size = new System.Drawing.Size(134, 22);
             this.ReloadButton.Text = "$RELOAD";
             this.ReloadButton.Click += new System.EventHandler(this.ReloadButton_Click);
             // 
             // ExitButton
             // 
             this.ExitButton.Name = "ExitButton";
-            this.ExitButton.Size = new System.Drawing.Size(180, 22);
+            this.ExitButton.Size = new System.Drawing.Size(134, 22);
             this.ExitButton.Text = "$EXIT";
             this.ExitButton.Click += new System.EventHandler(this.ExitButton_Click);
             // 
@@ -146,60 +153,60 @@
             this.toolButton.Image = ((System.Drawing.Image)(resources.GetObject("toolButton.Image")));
             this.toolButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolButton.Name = "toolButton";
-            this.toolButton.Size = new System.Drawing.Size(61, 22);
+            this.toolButton.Size = new System.Drawing.Size(63, 22);
             this.toolButton.Text = "$TOOLS";
             // 
             // AddAreaButton
             // 
             this.AddAreaButton.Name = "AddAreaButton";
-            this.AddAreaButton.Size = new System.Drawing.Size(233, 22);
+            this.AddAreaButton.Size = new System.Drawing.Size(239, 22);
             this.AddAreaButton.Text = "$ADD_AREA";
             this.AddAreaButton.Click += new System.EventHandler(this.AddAreaButton_Click);
             // 
             // AddDataButton
             // 
             this.AddDataButton.Name = "AddDataButton";
-            this.AddDataButton.Size = new System.Drawing.Size(233, 22);
+            this.AddDataButton.Size = new System.Drawing.Size(239, 22);
             this.AddDataButton.Text = "$ADD_DATA";
             this.AddDataButton.Click += new System.EventHandler(this.AddDataButton_Click);
             // 
             // DuplicateDataButton
             // 
             this.DuplicateDataButton.Name = "DuplicateDataButton";
-            this.DuplicateDataButton.Size = new System.Drawing.Size(233, 22);
+            this.DuplicateDataButton.Size = new System.Drawing.Size(239, 22);
             this.DuplicateDataButton.Text = "$DUPLICATE_DATA";
             this.DuplicateDataButton.Click += new System.EventHandler(this.DuplicateData_OnClick);
             // 
             // PopulateTranslokatorButton
             // 
             this.PopulateTranslokatorButton.Name = "PopulateTranslokatorButton";
-            this.PopulateTranslokatorButton.Size = new System.Drawing.Size(233, 22);
+            this.PopulateTranslokatorButton.Size = new System.Drawing.Size(239, 22);
             this.PopulateTranslokatorButton.Text = "$POPULATE_TRANSLOKATORS";
             this.PopulateTranslokatorButton.Click += new System.EventHandler(this.PopulateTranslokatorButton_Click);
             // 
             // DeleteAreaButton
             // 
             this.DeleteAreaButton.Name = "DeleteAreaButton";
-            this.DeleteAreaButton.Size = new System.Drawing.Size(233, 22);
+            this.DeleteAreaButton.Size = new System.Drawing.Size(239, 22);
             this.DeleteAreaButton.Text = "$DELETE_AREA";
             this.DeleteAreaButton.Click += new System.EventHandler(this.DeleteArea_Click);
             // 
             // DeleteDataButton
             // 
             this.DeleteDataButton.Name = "DeleteDataButton";
-            this.DeleteDataButton.Size = new System.Drawing.Size(233, 22);
+            this.DeleteDataButton.Size = new System.Drawing.Size(239, 22);
             this.DeleteDataButton.Text = "$DELETE_DATA";
             this.DeleteDataButton.Click += new System.EventHandler(this.DeleteData_Click);
             // 
-            // treeView1
+            // TreeView_CityShop
             // 
-            this.treeView1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.TreeView_CityShop.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
-            this.treeView1.Location = new System.Drawing.Point(12, 28);
-            this.treeView1.Name = "treeView1";
-            this.treeView1.Size = new System.Drawing.Size(309, 410);
-            this.treeView1.TabIndex = 16;
-            this.treeView1.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OnAfterSelect);
+            this.TreeView_CityShop.Location = new System.Drawing.Point(12, 28);
+            this.TreeView_CityShop.Name = "TreeView_CityShop";
+            this.TreeView_CityShop.Size = new System.Drawing.Size(309, 410);
+            this.TreeView_CityShop.TabIndex = 16;
+            this.TreeView_CityShop.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OnAfterSelect);
             // 
             // propertyGrid1
             // 
@@ -257,19 +264,12 @@
             this.dataGridView1.Size = new System.Drawing.Size(447, 378);
             this.dataGridView1.TabIndex = 0;
             // 
-            // Button_SaveDLC
-            // 
-            this.Button_SaveDLC.Name = "Button_SaveDLC";
-            this.Button_SaveDLC.Size = new System.Drawing.Size(180, 22);
-            this.Button_SaveDLC.Text = "$SAVE_DLC";
-            this.Button_SaveDLC.Click += new System.EventHandler(this.SaveButtonDLC_Click);
-            // 
             // CityShopEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Controls.Add(this.treeView1);
+            this.Controls.Add(this.TreeView_CityShop);
             this.Controls.Add(this.toolStrip1);
             this.Controls.Add(this.TabControl);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -300,7 +300,7 @@
         private System.Windows.Forms.ToolStripMenuItem deletePlacementToolStripMenuItem;
         private System.Windows.Forms.ToolStripDropDownButton toolButton;
         private System.Windows.Forms.ToolStripMenuItem AddAreaButton;
-        private System.Windows.Forms.TreeView treeView1;
+        private System.Windows.Forms.TreeView TreeView_CityShop;
         private System.Windows.Forms.PropertyGrid propertyGrid1;
         private System.Windows.Forms.ToolStripMenuItem PopulateTranslokatorButton;
         private System.Windows.Forms.ToolStripMenuItem AddDataButton;

--- a/Mafia2Libs/Forms/CityShopEditor.cs
+++ b/Mafia2Libs/Forms/CityShopEditor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Windows.Forms;
 using ResourceTypes.City;
+using Utils.Helpers;
 using Utils.Language;
 using Utils.Settings;
 
@@ -45,7 +46,7 @@ namespace Mafia2Tool
 
         private void BuildData()
         {
-            treeView1.Nodes.Clear();
+            TreeView_CityShop.Nodes.Clear();
             propertyGrid1.SelectedObject = null;
             shopsData = new CityShops(cityShopsFile.FullName);
             TreeNode areaNode = new TreeNode("Areas");
@@ -65,8 +66,8 @@ namespace Mafia2Tool
                 areaNode.Nodes.Add(node);
             }
 
-            treeView1.Nodes.Add(areaNode);
-            treeView1.Nodes.Add(dataNode);
+            TreeView_CityShop.Nodes.Add(areaNode);
+            TreeView_CityShop.Nodes.Add(dataNode);
         }
 
         private void Save()
@@ -74,12 +75,12 @@ namespace Mafia2Tool
             shopsData.Areas.Clear();
             shopsData.AreaDatas.Clear();
 
-            foreach (TreeNode node in treeView1.Nodes[0].Nodes)
+            foreach (TreeNode node in TreeView_CityShop.Nodes[0].Nodes)
             {
                 shopsData.Areas.Add((CityShops.Area)node.Tag);
             }
 
-            foreach (TreeNode node in treeView1.Nodes[1].Nodes)
+            foreach (TreeNode node in TreeView_CityShop.Nodes[1].Nodes)
             {
                 shopsData.AreaDatas.Add((CityShops.AreaData)node.Tag);
             }
@@ -96,9 +97,9 @@ namespace Mafia2Tool
             shopsData.Areas.Add(area);
             TreeNode node = new TreeNode("New Area");
             node.Tag = area;
-            treeView1.Nodes[0].Nodes.Add(node);
+            TreeView_CityShop.Nodes[0].Nodes.Add(node);
             shopsData.PopulateTranslokatorEntities();
-            treeView1.SelectedNode = node;
+            TreeView_CityShop.SelectedNode = node;
         }
 
         private void SaveButtonDLC_Click(object sender, EventArgs e)
@@ -225,25 +226,25 @@ namespace Mafia2Tool
             shopsData.AreaDatas.Add(areaData);
             TreeNode node = new TreeNode("New Area Data");
             node.Tag = areaData;
-            treeView1.Nodes[1].Nodes.Add(node);
+            TreeView_CityShop.Nodes[1].Nodes.Add(node);
             shopsData.PopulateTranslokatorEntities();
-            treeView1.SelectedNode = node;
+            TreeView_CityShop.SelectedNode = node;
         }
 
         private void OnPropertyChanged(object s, PropertyValueChangedEventArgs e)
         {
             if(e.ChangedItem.Label == "Name")
-                treeView1.SelectedNode.Text = e.ChangedItem.Value.ToString();
+                TreeView_CityShop.SelectedNode.Text = e.ChangedItem.Value.ToString();
         }
 
         private void OnTabSelected(object sender, TabControlEventArgs e)
         {
             if(e.TabPage == DataGridTab)
             {
-                if (treeView1.SelectedNode.Tag != null)
+                if (TreeView_CityShop.SelectedNode.Tag != null)
                 {
-                    if (treeView1.SelectedNode.Tag.GetType() == typeof(CityShops.AreaData))
-                        UpdateDataGrid((CityShops.AreaData)treeView1.SelectedNode.Tag);
+                    if (TreeView_CityShop.SelectedNode.Tag.GetType() == typeof(CityShops.AreaData))
+                        UpdateDataGrid((CityShops.AreaData)TreeView_CityShop.SelectedNode.Tag);
                 }
             }
             else if(e.TabPage == PropertyGridTab)
@@ -255,41 +256,41 @@ namespace Mafia2Tool
 
         private void DuplicateData_OnClick(object sender, EventArgs e)
         {
-            if (treeView1.SelectedNode.Tag != null)
+            if (TreeView_CityShop.SelectedNode.Tag != null)
             {
-                if (treeView1.SelectedNode.Tag.GetType() == typeof(CityShops.AreaData))
+                if (TreeView_CityShop.SelectedNode.Tag.GetType() == typeof(CityShops.AreaData))
                 {
-                    CityShops.AreaData data = new CityShops.AreaData((CityShops.AreaData)treeView1.SelectedNode.Tag);
+                    CityShops.AreaData data = new CityShops.AreaData((CityShops.AreaData)TreeView_CityShop.SelectedNode.Tag);
                     shopsData.AreaDatas.Add(data);
                     data.Name += "_dupe";
                     TreeNode node = new TreeNode(data.Name);
                     node.Tag = data;
-                    treeView1.Nodes[1].Nodes.Add(node);
-                    treeView1.SelectedNode = node;
+                    TreeView_CityShop.Nodes[1].Nodes.Add(node);
+                    TreeView_CityShop.SelectedNode = node;
                 }
             }
         }
 
         private void DeleteArea_Click(object sender, EventArgs e)
         {
-            if (treeView1.SelectedNode.Tag != null)
+            if (TreeView_CityShop.SelectedNode.Tag != null)
             {
-                if (treeView1.SelectedNode.Tag.GetType() == typeof(CityShops.Area))
+                if (TreeView_CityShop.SelectedNode.Tag.GetType() == typeof(CityShops.Area))
                 {
-                    treeView1.Nodes.Remove(treeView1.SelectedNode);
-                    shopsData.Areas.Remove((CityShops.Area)treeView1.SelectedNode.Tag);
+                    TreeView_CityShop.Nodes.Remove(TreeView_CityShop.SelectedNode);
+                    shopsData.Areas.Remove((CityShops.Area)TreeView_CityShop.SelectedNode.Tag);
                 }
             }
         }
 
         private void DeleteData_Click(object sender, EventArgs e)
         {
-            if (treeView1.SelectedNode.Tag != null)
+            if (TreeView_CityShop.SelectedNode.Tag != null)
             {
-                if (treeView1.SelectedNode.Tag.GetType() == typeof(CityShops.AreaData))
+                if (TreeView_CityShop.SelectedNode.Tag.GetType() == typeof(CityShops.AreaData))
                 {
-                    treeView1.Nodes.Remove(treeView1.SelectedNode);
-                    shopsData.AreaDatas.Remove((CityShops.AreaData)treeView1.SelectedNode.Tag);
+                    TreeView_CityShop.Nodes.Remove(TreeView_CityShop.SelectedNode);
+                    shopsData.AreaDatas.Remove((CityShops.AreaData)TreeView_CityShop.SelectedNode.Tag);
                 }
             }
         }

--- a/Mafia2Libs/Forms/CutsceneEditor.Designer.cs
+++ b/Mafia2Libs/Forms/CutsceneEditor.Designer.cs
@@ -38,7 +38,7 @@
             this.AddItemButton = new System.Windows.Forms.ToolStripMenuItem();
             this.AddDefinitionButton = new System.Windows.Forms.ToolStripMenuItem();
             this.PropertyGrid_Cutscene = new System.Windows.Forms.PropertyGrid();
-            this.TreeView_Cutscene = new System.Windows.Forms.TreeView();
+            this.TreeView_Cutscene = new Controls.MTreeView();
             this.toolStrip1.SuspendLayout();
             this.SuspendLayout();
             // 

--- a/Mafia2Libs/Forms/CutsceneEditor.cs
+++ b/Mafia2Libs/Forms/CutsceneEditor.cs
@@ -2,6 +2,7 @@
 using ResourceTypes.Cutscene;
 using System;
 using System.Windows.Forms;
+using Utils.Helpers;
 
 namespace Mafia2Tool.Forms
 {

--- a/Mafia2Libs/Forms/Docking/DockSceneTree.Designer.cs
+++ b/Mafia2Libs/Forms/Docking/DockSceneTree.Designer.cs
@@ -46,7 +46,7 @@ namespace Forms.Docking
             this.Label_FilterFrame = new System.Windows.Forms.Label();
             this.TextBox_FilterFrame = new System.Windows.Forms.TextBox();
             this.Button_Search = new System.Windows.Forms.Button();
-            this.treeView1 = new Utils.Extensions.MTreeView();
+            this.treeView1 = new Mafia2Tool.Controls.MTreeView();
             this.EntryMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.Split_Main)).BeginInit();
             this.Split_Main.Panel1.SuspendLayout();
@@ -233,7 +233,7 @@ namespace Forms.Docking
         public System.Windows.Forms.ToolStripMenuItem DeleteButton;
         public System.Windows.Forms.ToolStripMenuItem DuplicateButton;
         public System.Windows.Forms.ToolStripMenuItem Export3DButton;
-        private Utils.Extensions.MTreeView treeView1;
+        private Mafia2Tool.Controls.MTreeView treeView1;
         public System.Windows.Forms.ToolStripMenuItem UpdateParent1Button;
         public System.Windows.Forms.ToolStripMenuItem UpdateParent2Button;
         private System.Windows.Forms.ToolStripMenuItem FrameActions;

--- a/Mafia2Libs/Forms/EntityDataStorageEditor.Designer.cs
+++ b/Mafia2Libs/Forms/EntityDataStorageEditor.Designer.cs
@@ -30,7 +30,7 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EntityDataStorageEditor));
             this.PropertyGrid_Item = new System.Windows.Forms.PropertyGrid();
-            this.TreeView_Tables = new System.Windows.Forms.TreeView();
+            this.TreeView_Tables = new Controls.MTreeView();
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.Button_File = new System.Windows.Forms.ToolStripDropDownButton();
             this.Button_Save = new System.Windows.Forms.ToolStripMenuItem();

--- a/Mafia2Libs/Forms/EntityDataStorageEditor.cs
+++ b/Mafia2Libs/Forms/EntityDataStorageEditor.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Windows.Forms;
 using ResourceTypes.EntityDataStorage;
+using Utils.Helpers;
 using Utils.Language;
 using Utils.Settings;
 

--- a/Mafia2Libs/Forms/GameExplorer.Designer.cs
+++ b/Mafia2Libs/Forms/GameExplorer.Designer.cs
@@ -34,7 +34,7 @@ namespace Mafia2Tool
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(GameExplorer));
             this.mainContainer = new System.Windows.Forms.SplitContainer();
-            this.folderView = new System.Windows.Forms.TreeView();
+            this.folderView = new Controls.MTreeView();
             this.imageBank = new System.Windows.Forms.ImageList(this.components);
             this.toolStripContainer1 = new System.Windows.Forms.ToolStripContainer();
             this.toolStrip2 = new System.Windows.Forms.ToolStrip();
@@ -42,7 +42,7 @@ namespace Mafia2Tool
             this.FolderPath = new System.Windows.Forms.ToolStripTextBox();
             this.buttonStripRefresh = new System.Windows.Forms.ToolStripButton();
             this.SearchEntryText = new System.Windows.Forms.ToolStripTextBox();
-            this.fileListView = new System.Windows.Forms.ListView();
+            this.fileListView = new Controls.MListView();
             this.columnName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnType = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnSize = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));

--- a/Mafia2Libs/Forms/GameExplorer.cs
+++ b/Mafia2Libs/Forms/GameExplorer.cs
@@ -11,6 +11,7 @@ using ResourceTypes.Misc;
 using Mafia2Tool.Forms;
 using SharpDX;
 using Core.IO;
+using Utils.Helpers;
 
 namespace Mafia2Tool
 {

--- a/Mafia2Libs/Forms/PrefabEditor.Designer.cs
+++ b/Mafia2Libs/Forms/PrefabEditor.Designer.cs
@@ -30,7 +30,7 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(PrefabEditor));
             this.Grid_Prefabs = new System.Windows.Forms.PropertyGrid();
-            this.TreeView_Prefabs = new System.Windows.Forms.TreeView();
+            this.TreeView_Prefabs = new Controls.MTreeView();
             this.Browser_ImportPRB = new System.Windows.Forms.OpenFileDialog();
             this.ToolStrip_Main = new System.Windows.Forms.ToolStrip();
             this.Button_File = new System.Windows.Forms.ToolStripDropDownButton();

--- a/Mafia2Libs/Forms/PrefabEditor.cs
+++ b/Mafia2Libs/Forms/PrefabEditor.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Windows.Forms;
 using Gibbed.Illusion.FileFormats.Hashing;
 using ResourceTypes.Prefab;
+using Utils.Helpers;
 using Utils.Language;
 using Utils.StringHelpers;
 

--- a/Mafia2Libs/Forms/SDSContentEditor.Designer.cs
+++ b/Mafia2Libs/Forms/SDSContentEditor.Designer.cs
@@ -29,7 +29,7 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SDSContentEditor));
-            this.ResourceTreeView = new System.Windows.Forms.TreeView();
+            this.ResourceTreeView = new Controls.MTreeView();
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.fileToolButton = new System.Windows.Forms.ToolStripDropDownButton();
             this.SaveButton = new System.Windows.Forms.ToolStripMenuItem();

--- a/Mafia2Libs/Forms/SDSContentEditor.cs
+++ b/Mafia2Libs/Forms/SDSContentEditor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Windows.Forms;
+using Utils.Helpers;
 using Utils.Types;
 
 namespace Mafia2Tool

--- a/Mafia2Libs/Forms/ShopMenu2Editor.Designer.cs
+++ b/Mafia2Libs/Forms/ShopMenu2Editor.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(ShopMenu2Editor));
             this.PropertyGrid_ShopMenu2 = new System.Windows.Forms.PropertyGrid();
-            this.TreeView_ShopMenu2 = new System.Windows.Forms.TreeView();
+            this.TreeView_ShopMenu2 = new Controls.MTreeView();
             this.CollisionContext = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.ContextDelete = new System.Windows.Forms.ToolStripMenuItem();
             this.deletePlacementToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();

--- a/Mafia2Libs/Forms/ShopMenu2Editor.cs
+++ b/Mafia2Libs/Forms/ShopMenu2Editor.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Windows.Forms;
+using Utils.Helpers;
 using Utils.Language;
 using ResourceTypes.City;
 

--- a/Mafia2Libs/Forms/SpeechEditor.Designer.cs
+++ b/Mafia2Libs/Forms/SpeechEditor.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SpeechEditor));
             this.FrameResourceGrid = new System.Windows.Forms.PropertyGrid();
-            this.treeView1 = new System.Windows.Forms.TreeView();
+            this.TreeView_Speech = new Controls.MTreeView();
             this.CollisionContext = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.ContextDelete = new System.Windows.Forms.ToolStripMenuItem();
             this.deletePlacementToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -56,16 +56,16 @@
             this.FrameResourceGrid.Size = new System.Drawing.Size(386, 410);
             this.FrameResourceGrid.TabIndex = 10;
             // 
-            // treeView1
+            // TreeView_Speech
             // 
-            this.treeView1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.TreeView_Speech.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
-            this.treeView1.ContextMenuStrip = this.CollisionContext;
-            this.treeView1.Location = new System.Drawing.Point(12, 28);
-            this.treeView1.Name = "treeView1";
-            this.treeView1.Size = new System.Drawing.Size(368, 410);
-            this.treeView1.TabIndex = 11;
-            this.treeView1.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OnNodeSelectSelect);
+            this.TreeView_Speech.ContextMenuStrip = this.CollisionContext;
+            this.TreeView_Speech.Location = new System.Drawing.Point(12, 28);
+            this.TreeView_Speech.Name = "TreeView_Speech";
+            this.TreeView_Speech.Size = new System.Drawing.Size(368, 410);
+            this.TreeView_Speech.TabIndex = 11;
+            this.TreeView_Speech.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OnNodeSelectSelect);
             // 
             // CollisionContext
             // 
@@ -144,7 +144,7 @@
             this.ClientSize = new System.Drawing.Size(800, 450);
             this.Controls.Add(this.toolStrip1);
             this.Controls.Add(this.FrameResourceGrid);
-            this.Controls.Add(this.treeView1);
+            this.Controls.Add(this.TreeView_Speech);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "SpeechEditor";
             this.Text = "$SPEECH_EDITOR_TITLE";
@@ -159,7 +159,7 @@
         #endregion
 
         private System.Windows.Forms.PropertyGrid FrameResourceGrid;
-        private System.Windows.Forms.TreeView treeView1;
+        private System.Windows.Forms.TreeView TreeView_Speech;
         private System.Windows.Forms.OpenFileDialog openM2T;
         private System.Windows.Forms.ToolStrip toolStrip1;
         private System.Windows.Forms.ToolStripDropDownButton fileToolButton;

--- a/Mafia2Libs/Forms/SpeechEditor.cs
+++ b/Mafia2Libs/Forms/SpeechEditor.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Windows.Forms;
 using ResourceTypes.Speech;
+using Utils.Helpers;
 using Utils.Language;
 using Utils.Settings;
 
@@ -58,7 +59,7 @@ namespace Mafia2Tool
                         num = 0;
                     }
                 }
-                treeView1.Nodes.Add(node);
+                TreeView_Speech.Nodes.Add(node);
             }
         }
 

--- a/Mafia2Libs/Forms/StreamEditor.Designer.cs
+++ b/Mafia2Libs/Forms/StreamEditor.Designer.cs
@@ -50,9 +50,9 @@ namespace Mafia2Tool
             this.tabControl = new System.Windows.Forms.TabControl();
             this.StreamLinesPage = new System.Windows.Forms.TabPage();
             this.StreamGroupPage = new System.Windows.Forms.TabPage();
-            this.groupTree = new Utils.Extensions.MTreeView();
+            this.groupTree = new Mafia2Tool.Controls.MTreeView();
             this.StreamBlocksPage = new System.Windows.Forms.TabPage();
-            this.blockView = new Utils.Extensions.MTreeView();
+            this.blockView = new Mafia2Tool.Controls.MTreeView();
             this.SearchBox = new System.Windows.Forms.TextBox();
             this.LineContextStrip.SuspendLayout();
             this.ToolStrip.SuspendLayout();
@@ -306,8 +306,8 @@ namespace Mafia2Tool
         private TabPage StreamLinesPage;
         private TabPage StreamGroupPage;
         private TabPage StreamBlocksPage;
-        private Utils.Extensions.MTreeView groupTree;
-        private Utils.Extensions.MTreeView blockView;
+        private Mafia2Tool.Controls.MTreeView groupTree;
+        private Mafia2Tool.Controls.MTreeView blockView;
         private ContextMenuStrip LineContextStrip;
         private ToolStripMenuItem AddLineButton;
         private ToolStripMenuItem DeleteLineButton;

--- a/Mafia2Libs/Forms/TranslokatorEditor.Designer.cs
+++ b/Mafia2Libs/Forms/TranslokatorEditor.Designer.cs
@@ -31,7 +31,7 @@
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(TranslokatorEditor));
             this.PropertyGrid = new System.Windows.Forms.PropertyGrid();
-            this.TranslokatorTree = new System.Windows.Forms.TreeView();
+            this.TranslokatorTree = new Controls.MTreeView();
             this.TranslokatorContext = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.AddInstance = new System.Windows.Forms.ToolStripMenuItem();
             this.AddObject = new System.Windows.Forms.ToolStripMenuItem();

--- a/Mafia2Libs/Forms/TranslokatorEditor.cs
+++ b/Mafia2Libs/Forms/TranslokatorEditor.cs
@@ -3,6 +3,7 @@ using System.IO;
 using ResourceTypes.Translokator;
 using System.Windows.Forms;
 using Utils.Language;
+using Utils.Helpers;
 
 namespace Mafia2Tool.Forms
 {

--- a/Mafia2Libs/Forms/XBinEditor.Designer.cs
+++ b/Mafia2Libs/Forms/XBinEditor.Designer.cs
@@ -30,7 +30,7 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(XBinEditor));
             this.Grid_XBin = new System.Windows.Forms.PropertyGrid();
-            this.TreeView_XBin = new System.Windows.Forms.TreeView();
+            this.TreeView_XBin = new Controls.MTreeView();
             this.ToolStrip_Main = new System.Windows.Forms.ToolStrip();
             this.Button_File = new System.Windows.Forms.ToolStripDropDownButton();
             this.Button_Save = new System.Windows.Forms.ToolStripMenuItem();

--- a/Mafia2Libs/Forms/XBinEditor.cs
+++ b/Mafia2Libs/Forms/XBinEditor.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Windows.Forms;
 using ResourceTypes.M3.XBin;
+using Utils.Helpers;
 using Utils.Language;
 
 namespace Mafia2Tool
@@ -31,6 +32,9 @@ namespace Mafia2Tool
             Button_Save.Text = Language.GetString("$SAVE");
             Button_Reload.Text = Language.GetString("$RELOAD");
             Button_Exit.Text = Language.GetString("$EXIT");
+            Button_Tools.Text = Language.GetString("$TOOLS");
+            Button_Import.Text = Language.GetString("$IMPORT_XBIN");
+            Button_Export.Text = Language.GetString("$EXPORT_XBIN");
         }
 
         private void ReadFromFile()

--- a/Mafia2Libs/Localisations/cz_CZ.xml
+++ b/Mafia2Libs/Localisations/cz_CZ.xml
@@ -270,5 +270,10 @@
 
   <!-- Property Descriptions Strings-->
   <String ID="$XBIN_PROP_DESC_NAME_UNSTORED">Note: This is NOT stored in the file and taken from the 'Hash' value.</String>
-  
+
+  <!-- XBIN Editor Strings-->
+  <String ID="$XBIN_EDITOR_TITLE">XBIN Editor</String>
+  <String ID="$IMPORT_XBIN">Import from .xml</String>
+  <String ID="$EXPORT_XBIN">Export to .xml</String>
+
 </Localisation>

--- a/Mafia2Libs/Localisations/en_gb.xml
+++ b/Mafia2Libs/Localisations/en_gb.xml
@@ -275,5 +275,10 @@
   
   <!-- Property Descriptions Strings-->
   <String ID="$XBIN_PROP_DESC_NAME_UNSTORED">Note: This is NOT stored in the file and taken from the 'Hash' value.</String>
+
+  <!-- XBIN Editor Strings-->
+  <String ID="$XBIN_EDITOR_TITLE">XBIN Editor</String>
+  <String ID="$IMPORT_XBIN">Import from .xml</String>
+  <String ID="$EXPORT_XBIN">Export to .xml</String>
   
 </Localisation>

--- a/Mafia2Libs/Localisations/fr_FR.xml
+++ b/Mafia2Libs/Localisations/fr_FR.xml
@@ -203,5 +203,10 @@
 
   <!-- Property Descriptions Strings-->
   <String ID="$XBIN_PROP_DESC_NAME_UNSTORED">Note: This is NOT stored in the file and taken from the 'Hash' value.</String>
+
+  <!-- XBIN Editor Strings-->
+  <String ID="$XBIN_EDITOR_TITLE">XBIN Editor</String>
+  <String ID="$IMPORT_XBIN">Import from .xml</String>
+  <String ID="$EXPORT_XBIN">Export to .xml</String>
   
 </Localisation>

--- a/Mafia2Libs/Localisations/pl_PL.xml
+++ b/Mafia2Libs/Localisations/pl_PL.xml
@@ -262,5 +262,10 @@
   
   <!-- Property Descriptions Strings-->
   <String ID="$XBIN_PROP_DESC_NAME_UNSTORED">Note: This is NOT stored in the file and taken from the 'Hash' value.</String>
-  
+
+  <!-- XBIN Editor Strings-->
+  <String ID="$XBIN_EDITOR_TITLE">XBIN Editor</String>
+  <String ID="$IMPORT_XBIN">Import from .xml</String>
+  <String ID="$EXPORT_XBIN">Export to .xml</String>
+
 </Localisation>

--- a/Mafia2Libs/Localisations/ru_RU.xml
+++ b/Mafia2Libs/Localisations/ru_RU.xml
@@ -211,5 +211,10 @@
 
   <!-- Property Descriptions Strings-->
   <String ID="$XBIN_PROP_DESC_NAME_UNSTORED">Note: This is NOT stored in the file and taken from the 'Hash' value.</String>
-  
+
+  <!-- XBIN Editor Strings-->
+  <String ID="$XBIN_EDITOR_TITLE">XBIN Editor</String>
+  <String ID="$IMPORT_XBIN">Import from .xml</String>
+  <String ID="$EXPORT_XBIN">Export to .xml</String>
+
 </Localisation>

--- a/Mafia2Libs/Localisations/sk_SK.xml
+++ b/Mafia2Libs/Localisations/sk_SK.xml
@@ -262,5 +262,10 @@
 
   <!-- Property Descriptions Strings-->
   <String ID="$XBIN_PROP_DESC_NAME_UNSTORED">Note: This is NOT stored in the file and taken from the 'Hash' value.</String>
-  
+
+  <!-- XBIN Editor Strings-->
+  <String ID="$XBIN_EDITOR_TITLE">XBIN Editor</String>
+  <String ID="$IMPORT_XBIN">Import from .xml</String>
+  <String ID="$EXPORT_XBIN">Export to .xml</String>
+
 </Localisation>

--- a/Mafia2Libs/MafiaToolkit.csproj
+++ b/Mafia2Libs/MafiaToolkit.csproj
@@ -207,6 +207,12 @@
     <Compile Include="Controls\FrameResourceModelOptions.Designer.cs">
       <DependentUpon>FrameResourceModelOptions.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\MListView.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Controls\MTreeView.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Controls\RenderOptions.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -737,9 +743,7 @@
     <Compile Include="Rendering\Graphics\Shaders\Shader_601151254.cs" />
     <Compile Include="Rendering\Graphics\TextureClass.cs" />
     <Compile Include="Rendering\Input\InputClass.cs" />
-    <Compile Include="Utils\Helpers\Extensions.cs">
-      <SubType>Component</SubType>
-    </Compile>
+    <Compile Include="Utils\Helpers\Extensions.cs" />
     <Compile Include="Utils\Types\IniFile.cs" />
     <Compile Include="Forms\MaterialEditor.cs">
       <SubType>Form</SubType>

--- a/Mafia2Libs/Utils/Helpers/Extensions.cs
+++ b/Mafia2Libs/Utils/Helpers/Extensions.cs
@@ -11,26 +11,6 @@ using System.Windows.Forms.Design;
 
 namespace Utils.Extensions
 {
-    public sealed class MTreeView : TreeView
-    {
-
-        //fix from: (gotta love stack overflow!)
-        //https://stackoverflow.com/questions/14647216/c-sharp-treeview-ignore-double-click-only-at-checkbox
-        protected override void WndProc(ref Message m)
-        {
-            if (m.Msg == 0x0203 && CheckBoxes)
-            {
-                var localPos = this.PointToClient(Cursor.Position);
-                var hitTestInfo = this.HitTest(localPos);
-                if (hitTestInfo.Location == TreeViewHitTestLocations.StateImage)
-                {
-                    m.Msg = 0x0201;
-                }
-            }
-            base.WndProc(ref m);
-        }
-    }
-
     public class MTableColumn : DataGridViewColumn
     {
         private byte unk2;


### PR DESCRIPTION
- Using double buffered ListView and TreeView to prevent flickering when repainting.
- Added missing localization entires for xbin editor.

This PR is functionally equivalent to PR #33 , but uses inherited controls to realize the double buffering.
I believe its much nicer than remembering to manually call "SetDoubleBuffered()" via extension methods.