### PR TITLE
Load Oodle directly from game directory

### DIFF
--- a/Mafia2Libs/Forms/MapEditor.Designer.cs
+++ b/Mafia2Libs/Forms/MapEditor.Designer.cs
@@ -35,10 +35,10 @@ namespace Mafia2Tool
             System.Windows.Forms.StatusStrip StatusStrip;
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MapEditor));
             this.CurrentModeButton = new System.Windows.Forms.ToolStripSplitButton();
-            this.PositionXTool = new Utils.Extensions.NumericUpDownToolStrip();
-            this.PositionYTool = new Utils.Extensions.NumericUpDownToolStrip();
-            this.PositionZTool = new Utils.Extensions.NumericUpDownToolStrip();
-            this.CameraSpeedTool = new Utils.Extensions.NumericUpDownToolStrip();
+            this.PositionXTool = new NumericUpDownToolStrip();
+            this.PositionYTool = new NumericUpDownToolStrip();
+            this.PositionZTool = new NumericUpDownToolStrip();
+            this.CameraSpeedTool = new NumericUpDownToolStrip();
             this.Label_FPS = new System.Windows.Forms.ToolStripStatusLabel();
             this.Label_MemoryUsage = new System.Windows.Forms.ToolStripStatusLabel();
             this.ToolbarStrip = new System.Windows.Forms.ToolStrip();

--- a/Mafia2Libs/Forms/MapEditor.cs
+++ b/Mafia2Libs/Forms/MapEditor.cs
@@ -22,6 +22,7 @@ using System.Windows.Forms;
 using Toolkit.Core;
 using Utils.Extensions;
 using Utils.Language;
+using Utils.Logging;
 using Utils.Models;
 using Utils.Settings;
 using Utils.VorticeUtils;
@@ -1253,7 +1254,7 @@ namespace Mafia2Tool
                             if (SceneData.FrameResource.FrameObjects.ContainsKey(model.Key))
                             {
                                 var frame = (SceneData.FrameResource.FrameObjects[model.Key] as FrameObjectBase);
-                                Utils.Logging.Log.WriteLine(string.Format("The toolkit has failed to analyse a model: {0} {1}", frame.Name, t));
+                                Log.WriteLine(string.Format("The toolkit has failed to analyse a model: {0} {1}", frame.Name, t));
                             }
                         }
 

--- a/Mafia2Libs/Gibbed.Mafia2.FileFormats/ArchiveFile.cs
+++ b/Mafia2Libs/Gibbed.Mafia2.FileFormats/ArchiveFile.cs
@@ -38,6 +38,7 @@ using Utils.Logging;
 using Utils.Settings;
 using Utils.Types;
 using System.Diagnostics;
+using Mafia2Tool.Utils;
 
 namespace Gibbed.Mafia2.FileFormats
 {
@@ -221,7 +222,7 @@ namespace Gibbed.Mafia2.FileFormats
 
             if (IsGameType(GamesEnumerator.MafiaI_DE))
             {
-                if (!File.Exists("oo2core_8_win64.dll"))
+                if (!OodleDllResolver.TryResolveFrom(GameStorage.Instance.GetSelectedGame().Directory))
                 {
                     MessageBox.Show(Language.GetString("$M1DE_OODLEERROR"), "Toolkit");
                     return;

--- a/Mafia2Libs/Localisations/cz_CZ.xml
+++ b/Mafia2Libs/Localisations/cz_CZ.xml
@@ -45,8 +45,8 @@
   <String ID="$REFRESH">Obnovit</String>
   <String ID="$FOLDER_PATH_TOOLTIP">Umístění složky</String>
   <String ID="$UP_TOOLTIP">Nahoru</String>
-  <String ID="$M1DE_OODLEERROR">The Oodle DLL is a non-free library by RAD Game Tools and is thus not included due to legal issues. Please copy 'oo2core_8_win64.dll' from the Mafia: Definitive Edition installation folder into the same folder as the Toolkit executable.</String>
-
+  <String ID="$M1DE_OODLEERROR">Could not find Oodle DLL which is required for compression/decompression. Please make sure 'oo2core_8_win64.dll' exists in game directory.</String>
+	
   <!-- Game Selector -->
   <String ID="$START_TOOLKIT">Zapnout Toolkit</String>
   <String ID="$FOLDER_PATH_LABEL">Složka hry:</String>

--- a/Mafia2Libs/Localisations/en_gb.xml
+++ b/Mafia2Libs/Localisations/en_gb.xml
@@ -45,7 +45,7 @@
   <String ID="$REFRESH">Refresh</String>
   <String ID="$FOLDER_PATH_TOOLTIP">Folder Path</String>
   <String ID="$UP_TOOLTIP">Up</String>
-  <String ID="$M1DE_OODLEERROR">The Oodle DLL is a non-free library by RAD Game Tools and is thus not included due to legal issues. Please copy 'oo2core_8_win64.dll' from the Mafia: Definitive Edition installation folder into the same folder as the Toolkit executable.</String>
+  <String ID="$M1DE_OODLEERROR">Could not find Oodle DLL which is required for compression/decompression. Please make sure 'oo2core_8_win64.dll' exists in game directory.</String>
   
   <!-- Game Selector -->
   <String ID="$START_TOOLKIT">Start Toolkit</String>

--- a/Mafia2Libs/Localisations/fr_FR.xml
+++ b/Mafia2Libs/Localisations/fr_FR.xml
@@ -39,7 +39,7 @@
   <String ID="$REFRESH">Actualiser</String>
   <String ID="$FOLDER_PATH_TOOLTIP">Chemin du dossier</String>
   <String ID="$UP_TOOLTIP">Up</String>
-  <String ID="$M1DE_OODLEERROR">The Oodle DLL is a non-free library by RAD Game Tools and is thus not included due to legal issues. Please copy 'oo2core_8_win64.dll' from the Mafia: Definitive Edition installation folder into the same folder as the Toolkit executable.</String>
+  <String ID="$M1DE_OODLEERROR">Could not find Oodle DLL which is required for compression/decompression. Please make sure 'oo2core_8_win64.dll' exists in game directory.</String>
 
   <!-- Game Selector -->
   <String ID="$START_TOOLKIT">Start Toolkit</String>

--- a/Mafia2Libs/Localisations/pl_PL.xml
+++ b/Mafia2Libs/Localisations/pl_PL.xml
@@ -45,7 +45,7 @@
   <String ID="$REFRESH">Odśwież</String>
   <String ID="$FOLDER_PATH_TOOLTIP">Ścieżka do folderu</String>
   <String ID="$UP_TOOLTIP">Widok w górę</String>
-  <String ID="$M1DE_OODLEERROR">Biblioteka DLL Oodle jest płatną biblioteką RAD Game Tools objętą prawami autorskimi i w związku z tym nie została ona dołączona. Aby uruchomić Mafia Toolkit skopiuj tą bibliotekę o nazwie "oo2core_8_win64.dll" z folderu instalacyjnego gry Mafia: Edycja Ostateczna do folderu, gdzie znajduje się plik wykonywalny (.exe) Mafia Toolkit.</String>
+  <String ID="$M1DE_OODLEERROR">Could not find Oodle DLL which is required for compression/decompression. Please make sure 'oo2core_8_win64.dll' exists in game directory.</String>
 
   <!-- Game Selector -->
   <String ID="$START_TOOLKIT">Start Toolkit</String>

--- a/Mafia2Libs/Localisations/ru_RU.xml
+++ b/Mafia2Libs/Localisations/ru_RU.xml
@@ -39,7 +39,7 @@
   <String ID="$REFRESH">Обновить</String>
   <String ID="$FOLDER_PATH_TOOLTIP">Путь к папке </String>
   <String ID="$UP_TOOLTIP">Вверх</String>
-  <String ID="$M1DE_OODLEERROR">The Oodle DLL is a non-free library by RAD Game Tools and is thus not included due to legal issues. Please copy 'oo2core_8_win64.dll' from the Mafia: Definitive Edition installation folder into the same folder as the Toolkit executable.</String>
+  <String ID="$M1DE_OODLEERROR">Не удалось найти библиотеку Oodle, необходимую для сжатия/распаковки архивов. Пожалуйста, убедитесь, что файл 'oo2core_8_win64.dll' присутствует в игровой директории.</String>
   
   <!-- Game Selector -->
   <String ID="$START_TOOLKIT">Запуск Toolkit</String>

--- a/Mafia2Libs/Localisations/sk_SK.xml
+++ b/Mafia2Libs/Localisations/sk_SK.xml
@@ -45,7 +45,7 @@
   <String ID="$REFRESH">Obnoviť</String>
   <String ID="$FOLDER_PATH_TOOLTIP">Cesta priečinka</String>
   <String ID="$UP_TOOLTIP">Hore</String>
-  <String ID="$M1DE_OODLEERROR">The Oodle DLL is a non-free library by RAD Game Tools and is thus not included due to legal issues. Please copy 'oo2core_8_win64.dll' from the Mafia: Definitive Edition installation folder into the same folder as the Toolkit executable.</String>
+  <String ID="$M1DE_OODLEERROR">Could not find Oodle DLL which is required for compression/decompression. Please make sure 'oo2core_8_win64.dll' exists in game directory.</String>
 
   <!-- Game Selector -->
   <String ID="$START_TOOLKIT">Start Toolkit</String>

--- a/Mafia2Libs/Utils/OodleDllResolver.cs
+++ b/Mafia2Libs/Utils/OodleDllResolver.cs
@@ -1,0 +1,48 @@
+﻿using OodleSharp;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Mafia2Tool.Utils
+{
+    public static class OodleDllResolver
+    {
+        private const string OodleDllName = "oo2core_8_win64.dll";
+
+        private static string LibraryFullPath;
+        private static bool IsInitialized;
+
+        public static bool TryResolveFrom(string libraryLocation)
+        {
+            if (IsInitialized)
+            {
+                return true;
+            }
+
+            LibraryFullPath = Path.Combine(libraryLocation, OodleDllName);
+
+            if (!File.Exists(LibraryFullPath))
+            {
+                return false;
+            }
+
+            NativeLibrary.SetDllImportResolver(typeof(Oodle).Assembly, OodleResolver);
+            IsInitialized = true;
+
+            return true;
+        }
+
+        private static IntPtr OodleResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            var libHandle = IntPtr.Zero;
+
+            if (libraryName == OodleDllName)
+            {
+                NativeLibrary.TryLoad(LibraryFullPath, out libHandle);
+            }
+            
+            return libHandle;
+        }
+    }
+}

--- a/Mafia2Libs/Utils/SceneData.cs
+++ b/Mafia2Libs/Utils/SceneData.cs
@@ -19,6 +19,7 @@ using ResourceTypes.Prefab;
 using ResourceTypes.Misc;
 using Utils.Types;
 using System.Diagnostics;
+using Utils.Models;
 
 namespace Mafia2Tool
 {
@@ -64,7 +65,7 @@ namespace Mafia2Tool
             List<NAVData> obj = new List<NAVData>();
 
             isBigEndian = forceBigEndian;
-            Utils.Models.VertexTranslator.IsBigEndian = forceBigEndian;
+            VertexTranslator.IsBigEndian = forceBigEndian;
 
             if (isBigEndian)
             {

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Not the best feature in this Toolkit, its primary reason it exists is because it
 
 **SDS Packing/Repacking:**
 
-This feature uses Gibbed's SDS code from his [repository](https://github.com/gibbed/Gibbed.Illusion), with multiple fixes and improvements. XML files and the games tables are automatically decompiled, with the option to decompile the LUA files. There is an option to unpack SDS files in the format like "SDS Tools GUI", for the people who would like to open the contents in ZModeler3. For repacking, the modder can either choose compressed or uncompressed in the toolkits options. Double clicking any SDS in the game explorer will unpack, and to repack right click the SDS you unpacked, and click "pack". SDS's from Mafia III and Mafia: DE are also supported. However, with Mafia: DE, the Toolkit requires the end-user (you) to copy and paste the 'Oodle' dll from the game folder into the Toolkit's library folder to function. The Toolkit *does not* redistribute this DLL.
+This feature uses Gibbed's SDS code from his [repository](https://github.com/gibbed/Gibbed.Illusion), with multiple fixes and improvements. XML files and the games tables are automatically decompiled, with the option to decompile the LUA files. There is an option to unpack SDS files in the format like "SDS Tools GUI", for the people who would like to open the contents in ZModeler3. For repacking, the modder can either choose compressed or uncompressed in the toolkits options. Double clicking any SDS in the game explorer will unpack, and to repack right click the SDS you unpacked, and click "pack". SDS's from Mafia III and Mafia: DE are also supported.
 
 **Material Editor:**
 


### PR DESCRIPTION
First commit is a fix for build errors I encountered locally.
Second one is the meat of this PR.

I've written a custom resolver so that we don't have to copy `oo2core_8_win64.dll` to toolkit folder anymore -- it's resolved directly from game directory.
This is a new .NET approach, wasn't available in .NET Framework, AFAICT.