### PR TITLE
Compact LOH on PCKEditor close to free memory

### DIFF
--- a/Mafia2Libs/Forms/PCKEditor.Designer.cs
+++ b/Mafia2Libs/Forms/PCKEditor.Designer.cs
@@ -248,6 +248,7 @@
             this.Name = "PCKEditor";
             this.Text = "$PCK_EDITOR_TITLE";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.PckEditor_Closing);
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.PckEditor_FormClosed);
             this.PckContext.ResumeLayout(false);
             this.ToolStrip_Pck.ResumeLayout(false);
             this.ToolStrip_Pck.PerformLayout();

--- a/Mafia2Libs/Forms/PCKEditor.cs
+++ b/Mafia2Libs/Forms/PCKEditor.cs
@@ -7,6 +7,8 @@ using Utils.Language;
 using Utils.Settings;
 using Forms.EditorControls;
 using System.Collections.Generic;
+using System.Runtime;
+using System.Threading.Tasks;
 
 namespace Mafia2Tool
 {
@@ -330,6 +332,18 @@ namespace Mafia2Tool
                     e.Cancel = true;
                 }
             }
+        }
+
+        private void PckEditor_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            // unreference memory-intensive objects (WEM)
+            TreeView_Wems.Nodes.Clear();
+            WemGrid.SelectedObject = null;
+            TreeView_Wems.SelectedNode = null;
+            pck = null;
+            // trigger LOH compactification
+            GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
+            GC.Collect();
         }
 
         private void Context_Opening(object sender, System.EventArgs e)

--- a/Mafia2Libs/Forms/PCKEditor.cs
+++ b/Mafia2Libs/Forms/PCKEditor.cs
@@ -1,14 +1,10 @@
-﻿using System.Diagnostics;
-using System;
+﻿using System;
 using System.IO;
+using System.Runtime;
 using System.Windows.Forms;
 using ResourceTypes.Wwise;
 using Utils.Language;
 using Utils.Settings;
-using Forms.EditorControls;
-using System.Collections.Generic;
-using System.Runtime;
-using System.Threading.Tasks;
 
 namespace Mafia2Tool
 {


### PR DESCRIPTION
`WEM` objects contain large `byte[]` field in them, and are placed in Large Object Heap (LOH) by memory allocator.
After form is closed, we need to unreference these objects, and then trigger GC. This way memory is reclaimed instantly.